### PR TITLE
[EC-61] BE/feat: 회의실 예약 취소 api 구현

### DIFF
--- a/api/src/main/java/org/example/educheck/domain/meetingroomreservation/controller/MeetingRoomReservationController.java
+++ b/api/src/main/java/org/example/educheck/domain/meetingroomreservation/controller/MeetingRoomReservationController.java
@@ -7,7 +7,6 @@ import org.example.educheck.domain.meetingroomreservation.dto.request.MeetingRoo
 import org.example.educheck.domain.meetingroomreservation.dto.response.MeetingRoomReservationResponseDto;
 import org.example.educheck.domain.meetingroomreservation.service.MeetingRoomReservationService;
 import org.example.educheck.global.common.dto.ApiResponse;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -45,8 +44,13 @@ public class MeetingRoomReservationController {
     public ResponseEntity<ApiResponse<Object>> cancelReservation(@AuthenticationPrincipal UserDetails userDetails,
                                                                  @PathVariable Long meetingRoomReservationId) {
         meetingRoomReservationService.cancelReservation(userDetails, meetingRoomReservationId);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT)
-                .body(ApiResponse.ok("예약 취소 성공", "NO_CONTENT", null));
-    }
 
+        return ResponseEntity.ok(
+                ApiResponse.ok(
+                        "회의실 예약 취소 성공",
+                        "OK",
+                        null
+                )
+        );
+    }
 }

--- a/api/src/main/java/org/example/educheck/domain/meetingroomreservation/controller/MeetingRoomReservationController.java
+++ b/api/src/main/java/org/example/educheck/domain/meetingroomreservation/controller/MeetingRoomReservationController.java
@@ -7,6 +7,7 @@ import org.example.educheck.domain.meetingroomreservation.dto.request.MeetingRoo
 import org.example.educheck.domain.meetingroomreservation.dto.response.MeetingRoomReservationResponseDto;
 import org.example.educheck.domain.meetingroomreservation.service.MeetingRoomReservationService;
 import org.example.educheck.global.common.dto.ApiResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -38,6 +39,14 @@ public class MeetingRoomReservationController {
                 )
         );
 
+    }
+
+    @DeleteMapping("/{meetingRoomReservationId}")
+    public ResponseEntity<ApiResponse<Object>> cancelReservation(@AuthenticationPrincipal UserDetails userDetails,
+                                                                 @PathVariable Long meetingRoomReservationId) {
+        meetingRoomReservationService.cancelReservation(userDetails, meetingRoomReservationId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT)
+                .body(ApiResponse.ok("예약 취소 성공", "NO_CONTENT", null));
     }
 
 }

--- a/api/src/main/java/org/example/educheck/domain/meetingroomreservation/dto/response/MeetingRoomReservationResponseDto.java
+++ b/api/src/main/java/org/example/educheck/domain/meetingroomreservation/dto/response/MeetingRoomReservationResponseDto.java
@@ -3,6 +3,7 @@ package org.example.educheck.domain.meetingroomreservation.dto.response;
 import lombok.Builder;
 import lombok.Getter;
 import org.example.educheck.domain.meetingroomreservation.entity.MeetingRoomReservation;
+import org.example.educheck.domain.meetingroomreservation.entity.ReservationStatus;
 
 import java.time.LocalDateTime;
 
@@ -15,6 +16,7 @@ public class MeetingRoomReservationResponseDto {
     private LocalDateTime endDateTime;
     private Long meetingRoomId;
     private String meetingRoomName;
+    private ReservationStatus status;
 
     public static MeetingRoomReservationResponseDto from(MeetingRoomReservation reservation) {
         return MeetingRoomReservationResponseDto.builder()
@@ -24,6 +26,7 @@ public class MeetingRoomReservationResponseDto {
                 .endDateTime(reservation.getEndTime())
                 .meetingRoomId(reservation.getMeetingRoom().getId())
                 .meetingRoomName(reservation.getMeetingRoom().getName())
+                .status(reservation.getStatus())
                 .build();
     }
 

--- a/api/src/main/java/org/example/educheck/domain/meetingroomreservation/entity/MeetingRoomReservation.java
+++ b/api/src/main/java/org/example/educheck/domain/meetingroomreservation/entity/MeetingRoomReservation.java
@@ -8,6 +8,8 @@ import lombok.NoArgsConstructor;
 import org.example.educheck.domain.meetingroom.entity.MeetingRoom;
 import org.example.educheck.domain.member.entity.Member;
 import org.example.educheck.global.common.entity.BaseTimeEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.LocalDateTime;
 
@@ -22,6 +24,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MeetingRoomReservation extends BaseTimeEntity {
 
+    private static final Logger log = LoggerFactory.getLogger(MeetingRoomReservation.class);
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -48,5 +51,9 @@ public class MeetingRoomReservation extends BaseTimeEntity {
         this.startTime = startTime;
         this.endTime = endTime;
         this.status = ReservationStatus.ACTIVE;
+    }
+
+    public void cancelReservation() {
+        this.status = ReservationStatus.CANCELED;
     }
 }

--- a/api/src/main/java/org/example/educheck/domain/meetingroomreservation/entity/MeetingRoomReservation.java
+++ b/api/src/main/java/org/example/educheck/domain/meetingroomreservation/entity/MeetingRoomReservation.java
@@ -37,11 +37,16 @@ public class MeetingRoomReservation extends BaseTimeEntity {
     private LocalDateTime startTime;
     private LocalDateTime endTime;
 
+    @Column(columnDefinition = "VARCHAR(20)")
+    @Enumerated(EnumType.STRING)
+    private ReservationStatus status;
+
     @Builder
     public MeetingRoomReservation(Member member, MeetingRoom meetingRoom, LocalDateTime startTime, LocalDateTime endTime) {
         this.member = member;
         this.meetingRoom = meetingRoom;
         this.startTime = startTime;
         this.endTime = endTime;
+        this.status = ReservationStatus.ACTIVE;
     }
 }

--- a/api/src/main/java/org/example/educheck/domain/meetingroomreservation/entity/ReservationStatus.java
+++ b/api/src/main/java/org/example/educheck/domain/meetingroomreservation/entity/ReservationStatus.java
@@ -1,0 +1,6 @@
+package org.example.educheck.domain.meetingroomreservation.entity;
+
+public enum ReservationStatus {
+    ACTIVE,
+    CANCELED
+}

--- a/api/src/main/java/org/example/educheck/domain/meetingroomreservation/repository/MeetingRoomReservationRepository.java
+++ b/api/src/main/java/org/example/educheck/domain/meetingroomreservation/repository/MeetingRoomReservationRepository.java
@@ -31,5 +31,10 @@ public interface MeetingRoomReservationRepository extends JpaRepository<MeetingR
             "WHERE r.id = :reservationId")
     Optional<MeetingRoomReservation> findByIdWithDetails(@Param("reservationId") Long reservationId);
 
+    @Query("SELECT r FROM MeetingRoomReservation r " +
+            "WHERE r.status = :status " +
+            "AND r.id = :reservationId")
+    Optional<MeetingRoomReservation> findByStatusAndById(@Param("reservationId") Long reservationId,
+                                                         @Param("status") ReservationStatus status);
 
 }

--- a/api/src/main/java/org/example/educheck/domain/meetingroomreservation/repository/MeetingRoomReservationRepository.java
+++ b/api/src/main/java/org/example/educheck/domain/meetingroomreservation/repository/MeetingRoomReservationRepository.java
@@ -2,6 +2,7 @@ package org.example.educheck.domain.meetingroomreservation.repository;
 
 import org.example.educheck.domain.meetingroom.entity.MeetingRoom;
 import org.example.educheck.domain.meetingroomreservation.entity.MeetingRoomReservation;
+import org.example.educheck.domain.meetingroomreservation.entity.ReservationStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,6 +14,7 @@ import java.util.Optional;
 public interface MeetingRoomReservationRepository extends JpaRepository<MeetingRoomReservation, Long> {
 
     @Query("SELECT COUNT(r) > 0 FROM MeetingRoomReservation r WHERE r.meetingRoom = :meetingRoom " +
+            "AND r.status = :status " +
             "AND FUNCTION('DATE',r.startTime)  = :date " +
             "AND ((r.startTime <= :endTime AND r.endTime > :startTime) " +
             "OR (r.startTime < :endTime AND r.endTime >= :endTime) " +
@@ -20,7 +22,8 @@ public interface MeetingRoomReservationRepository extends JpaRepository<MeetingR
     boolean existsOverlappingReservation(@Param("meetingRoom") MeetingRoom meetingRoom,
                                          @Param("date") LocalDate data,
                                          @Param("startTime") LocalDateTime startTime,
-                                         @Param("endTime") LocalDateTime endTime);
+                                         @Param("endTime") LocalDateTime endTime,
+                                         @Param("status") ReservationStatus status);
 
     @Query("SELECT r FROM MeetingRoomReservation r " +
             "JOIN FETCH r.member m " +

--- a/api/src/main/java/org/example/educheck/domain/meetingroomreservation/service/MeetingRoomReservationService.java
+++ b/api/src/main/java/org/example/educheck/domain/meetingroomreservation/service/MeetingRoomReservationService.java
@@ -114,7 +114,7 @@ public class MeetingRoomReservationService {
     @Transactional
     public void cancelReservation(UserDetails userDetails, Long meetingRoomReservationId) {
 
-        MeetingRoomReservation meetingRoomReservation = meetingRoomReservationRepository.findById(meetingRoomReservationId)
+        MeetingRoomReservation meetingRoomReservation = meetingRoomReservationRepository.findByStatusAndById(meetingRoomReservationId, ReservationStatus.ACTIVE)
                 .orElseThrow(() -> new ResourceNotFoundException("해당 예약 내역이 존재하지 않습니다."));
 
         Member authenticatedMember = getAuthenticatedMember(userDetails);

--- a/api/src/main/java/org/example/educheck/domain/meetingroomreservation/service/MeetingRoomReservationService.java
+++ b/api/src/main/java/org/example/educheck/domain/meetingroomreservation/service/MeetingRoomReservationService.java
@@ -6,6 +6,7 @@ import org.example.educheck.domain.meetingroom.repository.MeetingRoomRepository;
 import org.example.educheck.domain.meetingroomreservation.dto.request.MeetingRoomReservationRequestDto;
 import org.example.educheck.domain.meetingroomreservation.dto.response.MeetingRoomReservationResponseDto;
 import org.example.educheck.domain.meetingroomreservation.entity.MeetingRoomReservation;
+import org.example.educheck.domain.meetingroomreservation.entity.ReservationStatus;
 import org.example.educheck.domain.meetingroomreservation.repository.MeetingRoomReservationRepository;
 import org.example.educheck.domain.member.entity.Member;
 import org.example.educheck.domain.member.repository.MemberRepository;
@@ -90,7 +91,7 @@ public class MeetingRoomReservationService {
     private void validateReservableTime(MeetingRoom meetingRoom, LocalDateTime startTime, LocalDateTime endTime) {
         LocalDate date = startTime.toLocalDate();
         boolean result = meetingRoomReservationRepository.existsOverlappingReservation(meetingRoom,
-                date, startTime, endTime);
+                date, startTime, endTime, ReservationStatus.ACTIVE);
 
         if (result) {
             throw new ReservationConflictException();

--- a/api/src/main/java/org/example/educheck/domain/meetingroomreservation/service/MeetingRoomReservationService.java
+++ b/api/src/main/java/org/example/educheck/domain/meetingroomreservation/service/MeetingRoomReservationService.java
@@ -61,9 +61,6 @@ public class MeetingRoomReservationService {
         return memberRepository.findByEmail(user.getUsername()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 member입니다."));
     }
 
-    /**
-     * 예약은 9시부터 22시까지 가능
-     */
     private void validateReservationTime(LocalDateTime startTime, LocalDateTime endTime) {
 
         LocalTime startOfDay = LocalTime.of(9, 0);
@@ -98,7 +95,6 @@ public class MeetingRoomReservationService {
         }
     }
 
-    //TODO: 쿼리 발생하는거 확인 후, FETCH JOIN 처리 등 고려 하기
     private void validateUserCampusMatchMeetingRoom(Long campusId, MeetingRoom meetingRoom) {
 
         if (!campusId.equals(meetingRoom.getCampusId())) {
@@ -121,10 +117,9 @@ public class MeetingRoomReservationService {
         MeetingRoomReservation meetingRoomReservation = meetingRoomReservationRepository.findById(meetingRoomReservationId)
                 .orElseThrow(() -> new ResourceNotFoundException("해당 예약 내역이 존재하지 않습니다."));
 
-        // 예약자와 취소 신청자 일치하는지 유효성 검사
         Member authenticatedMember = getAuthenticatedMember(userDetails);
         validateResourceOwner(authenticatedMember, meetingRoomReservation);
-        // 예약 취소 처리 (소프트 딜리트)
+
         meetingRoomReservation.cancelReservation();
         meetingRoomReservationRepository.save(meetingRoomReservation);
     }

--- a/api/src/main/java/org/example/educheck/global/common/exception/ErrorCode.java
+++ b/api/src/main/java/org/example/educheck/global/common/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "4000", "입력값이 올바르지 않습니다."),
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "4004", "해당 리소스가 존재하지 않습니다."),
     MISMATCHED_RESOURCE(HttpStatus.BAD_REQUEST, "4008", "요청한 리소스가 일치하지 않습니다."),
+    NOT_OWNER(HttpStatus.FORBIDDEN, "4003", "본인만 수정 및 삭제 가능합니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "4010", "인증에 실패했습니다.");
 
     private final HttpStatus status;

--- a/api/src/main/java/org/example/educheck/global/common/exception/custom/common/ResourceOwnerMismatchException.java
+++ b/api/src/main/java/org/example/educheck/global/common/exception/custom/common/ResourceOwnerMismatchException.java
@@ -1,0 +1,2 @@
+package org.example.educheck.global.common.exception.custom.common;public class ResourceOwnerMismatchException {
+}

--- a/api/src/main/java/org/example/educheck/global/common/exception/custom/common/ResourceOwnerMismatchException.java
+++ b/api/src/main/java/org/example/educheck/global/common/exception/custom/common/ResourceOwnerMismatchException.java
@@ -1,2 +1,17 @@
-package org.example.educheck.global.common.exception.custom.common;public class ResourceOwnerMismatchException {
+package org.example.educheck.global.common.exception.custom.common;
+
+import org.example.educheck.global.common.exception.ErrorCode;
+
+public class ResourceOwnerMismatchException extends GlobalException {
+    public ResourceOwnerMismatchException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public ResourceOwnerMismatchException(String message) {
+        super(ErrorCode.MISMATCHED_RESOURCE, message);
+    }
+
+    public ResourceOwnerMismatchException() {
+        super(ErrorCode.MISMATCHED_RESOURCE);
+    }
 }


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- EC-61

## 📝 변경 사항

- 회의실 예약 취소 API 구현
- 취소 API 따른 생성 API 로직 리팩토링
- 회의실 예약 테이블에 취소 상태 관리를 위한 필드가 없어 추가했습니다.
  - ERD, 노션 API 문서 반영

## 📸 스크린샷

## ✅ PR 체크리스트

- [ ] 커밋 메시지에 Jira 이슈 번호 포함
- [ ] 관련 문서 업데이트 (필요한 경우)
- [ ] Jira 이슈 상태 업데이트

## 📌 참고 사항

