### PR TITLE
[EC-110] fix: 유고 결석 조회 api 변경

### DIFF
--- a/api/src/main/java/org/example/educheck/domain/absenceattendance/controller/AbsenceAttendanceController.java
+++ b/api/src/main/java/org/example/educheck/domain/absenceattendance/controller/AbsenceAttendanceController.java
@@ -84,7 +84,7 @@ public class AbsenceAttendanceController {
 
     @GetMapping("/course/{courseId}/absence-attendances")
     public ResponseEntity<ApiResponse<GetAbsenceAttendancesResponseDto>> getAbsenceAttendances(
-            @PathVariable Long courseId, @PageableDefault(sort = "startTime",
+            @PathVariable Long courseId, @PageableDefault(sort = "createdAt",
             direction = Sort.Direction.DESC,
             size = 10)
     Pageable pageable, @AuthenticationPrincipal Member member) {

--- a/api/src/main/java/org/example/educheck/domain/absenceattendance/dto/response/GetAbsenceAttendancesResponseDto.java
+++ b/api/src/main/java/org/example/educheck/domain/absenceattendance/dto/response/GetAbsenceAttendancesResponseDto.java
@@ -11,6 +11,7 @@ import org.example.educheck.global.common.exception.custom.common.ResourceNotFou
 import org.springframework.data.domain.Page;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -57,6 +58,7 @@ public class GetAbsenceAttendancesResponseDto {
         private boolean isAttached;
         private LocalDate startDate;
         private LocalDate endDate;
+        private LocalDateTime createdAt;
 
 
         public static AbsenceAttendancesDto from(AbsenceAttendance absenceAttendance) {
@@ -68,6 +70,7 @@ public class GetAbsenceAttendancesResponseDto {
                     .isAttached(!absenceAttendance.getAbsenceAttendanceAttachmentFiles().isEmpty())
                     .startDate(absenceAttendance.getStartTime())
                     .endDate(absenceAttendance.getEndTime())
+                    .createdAt(absenceAttendance.getCreatedAt())
                     .build();
         }
     }


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- EC-110

## 📝 변경 사항

- responsedto에 createdAt 필드 추가
- 정렬 기준 createdAt으로 변경

## ✅ PR 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [x] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트

## 📌 참고 사항

- 노드 추가 패키지 설치
