### PR TITLE
[EC-127] BE/feat: 수강생 유고 결석 신청 내역 조회 API

### DIFF
--- a/api/src/main/java/org/example/educheck/domain/absenceattendance/controller/AbsenceAttendanceController.java
+++ b/api/src/main/java/org/example/educheck/domain/absenceattendance/controller/AbsenceAttendanceController.java
@@ -4,10 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.example.educheck.domain.absenceattendance.dto.request.CreateAbsenceAttendacneRequestDto;
 import org.example.educheck.domain.absenceattendance.dto.request.ProcessAbsenceAttendanceRequestDto;
 import org.example.educheck.domain.absenceattendance.dto.request.UpdateAbsenceAttendacneRequestDto;
-import org.example.educheck.domain.absenceattendance.dto.response.AbsenceAttendanceResponseDto;
-import org.example.educheck.domain.absenceattendance.dto.response.CreateAbsenceAttendacneReponseDto;
-import org.example.educheck.domain.absenceattendance.dto.response.GetAbsenceAttendancesResponseDto;
-import org.example.educheck.domain.absenceattendance.dto.response.UpdateAbsenceAttendacneReponseDto;
+import org.example.educheck.domain.absenceattendance.dto.response.*;
 import org.example.educheck.domain.absenceattendance.service.AbsenceAttendanceService;
 import org.example.educheck.domain.member.entity.Member;
 import org.example.educheck.global.common.dto.ApiResponse;
@@ -20,6 +17,8 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -95,10 +94,11 @@ public class AbsenceAttendanceController {
 
     }
 
+    @PreAuthorize("hasAnyAuthority('STUDENT','MIDDLE_ADMIN')")
     @GetMapping("/course/{courseId}/absence-attendances/{absenceAttendancesId}")
-    public ResponseEntity<ApiResponse<AbsenceAttendanceResponseDto>> getAbsenceAttendance(@AuthenticationPrincipal Member member,
-                                                                                          @PathVariable Long courseId,
-                                                                                          @PathVariable Long absenceAttendancesId
+    public ResponseEntity<ApiResponse<AbsenceAttendanceResponseDto>> c(@AuthenticationPrincipal Member member,
+                                                                       @PathVariable Long courseId,
+                                                                       @PathVariable Long absenceAttendancesId
     ) {
         return ResponseEntity.ok(
                 ApiResponse.ok("유고 결석 신청 내역 상세 조회 성공",
@@ -106,4 +106,19 @@ public class AbsenceAttendanceController {
                         absenceAttendanceService.getAbsenceAttendance(member, courseId, absenceAttendancesId))
         );
     }
+
+    @PreAuthorize("hasAuthority('STUDENT')")
+    @GetMapping("/my/course/{courseId}/absence-attendances")
+    public ResponseEntity<ApiResponse<List<MyAbsenceAttendanceResponseDto>>> getMyAbsenceAttendances(@AuthenticationPrincipal Member member,
+                                                                                                     @PathVariable Long courseId) {
+        
+        return ResponseEntity.ok(
+                ApiResponse.ok("유고 결석 신청 목록 조회 성공",
+                        "OK",
+                        absenceAttendanceService.getMyAbsenceAttendances(member, courseId))
+
+        );
+    }
+
+
 }

--- a/api/src/main/java/org/example/educheck/domain/absenceattendance/controller/AbsenceAttendanceController.java
+++ b/api/src/main/java/org/example/educheck/domain/absenceattendance/controller/AbsenceAttendanceController.java
@@ -8,6 +8,7 @@ import org.example.educheck.domain.absenceattendance.dto.response.*;
 import org.example.educheck.domain.absenceattendance.service.AbsenceAttendanceService;
 import org.example.educheck.domain.member.entity.Member;
 import org.example.educheck.global.common.dto.ApiResponse;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -17,8 +18,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -109,13 +108,17 @@ public class AbsenceAttendanceController {
 
     @PreAuthorize("hasAuthority('STUDENT')")
     @GetMapping("/my/course/{courseId}/absence-attendances")
-    public ResponseEntity<ApiResponse<List<MyAbsenceAttendanceResponseDto>>> getMyAbsenceAttendances(@AuthenticationPrincipal Member member,
-                                                                                                     @PathVariable Long courseId) {
-        
+    public ResponseEntity<ApiResponse<Page<MyAbsenceAttendanceResponseDto>>> getMyAbsenceAttendances(@AuthenticationPrincipal Member member,
+                                                                                                     @PathVariable Long courseId,
+                                                                                                     @PageableDefault(sort = "createdAt",
+                                                                                                             direction = Sort.Direction.DESC,
+                                                                                                             size = 4) Pageable pageable) {
+
+
         return ResponseEntity.ok(
                 ApiResponse.ok("유고 결석 신청 목록 조회 성공",
                         "OK",
-                        absenceAttendanceService.getMyAbsenceAttendances(member, courseId))
+                        absenceAttendanceService.getMyAbsenceAttendances(member, courseId, pageable))
 
         );
     }

--- a/api/src/main/java/org/example/educheck/domain/absenceattendance/dto/response/MyAbsenceAttendanceResponseDto.java
+++ b/api/src/main/java/org/example/educheck/domain/absenceattendance/dto/response/MyAbsenceAttendanceResponseDto.java
@@ -1,0 +1,25 @@
+package org.example.educheck.domain.absenceattendance.dto.response;
+
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class MyAbsenceAttendanceResponseDto {
+
+    private Long absenceAttendanceId;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private Character isApprove;
+    private String category;
+
+    public MyAbsenceAttendanceResponseDto(Long id, LocalDate startTime, LocalDate endTime,
+                                          Character isApprove, String category) {
+        this.absenceAttendanceId = id;
+        this.startDate = startTime;
+        this.endDate = endTime;
+        this.isApprove = isApprove;
+        this.category = category;
+    }
+
+}

--- a/api/src/main/java/org/example/educheck/domain/absenceattendance/dto/response/MyAbsenceAttendanceResponseDto.java
+++ b/api/src/main/java/org/example/educheck/domain/absenceattendance/dto/response/MyAbsenceAttendanceResponseDto.java
@@ -1,10 +1,12 @@
 package org.example.educheck.domain.absenceattendance.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Getter;
 
 import java.time.LocalDate;
 
 @Getter
+@JsonPropertyOrder({"absenceAttendanceId", "startDate", "endDate", "isApprove", "category"})
 public class MyAbsenceAttendanceResponseDto {
 
     private Long absenceAttendanceId;

--- a/api/src/main/java/org/example/educheck/domain/absenceattendance/dto/response/MyAbsenceAttendancesResponseListDto.java
+++ b/api/src/main/java/org/example/educheck/domain/absenceattendance/dto/response/MyAbsenceAttendancesResponseListDto.java
@@ -1,0 +1,4 @@
+package org.example.educheck.domain.absenceattendance.dto.response;
+
+public class MyAbsenceAttendancesResponseListDto {
+}

--- a/api/src/main/java/org/example/educheck/domain/absenceattendance/repository/AbsenceAttendanceRepository.java
+++ b/api/src/main/java/org/example/educheck/domain/absenceattendance/repository/AbsenceAttendanceRepository.java
@@ -16,7 +16,8 @@ public interface AbsenceAttendanceRepository extends JpaRepository<AbsenceAttend
     @Query("SELECT new org.example.educheck.domain.absenceattendance.dto.response.MyAbsenceAttendanceResponseDto( " +
             "a.id, a.startTime, a.endTime, a.isApprove, a.category) " +
             "FROM AbsenceAttendance a " +
-            "WHERE a.course.id = :courseId AND a.student.id = :studentId")
+            "WHERE a.course.id = :courseId AND a.student.id = :studentId " +
+            "ORDER BY a.id DESC")
     List<MyAbsenceAttendanceResponseDto> findByStudentIdAndCourseId(@Param("studentId") Long studentId, @Param("courseId") Long courseId);
 
 }

--- a/api/src/main/java/org/example/educheck/domain/absenceattendance/repository/AbsenceAttendanceRepository.java
+++ b/api/src/main/java/org/example/educheck/domain/absenceattendance/repository/AbsenceAttendanceRepository.java
@@ -8,16 +8,16 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
-
 public interface AbsenceAttendanceRepository extends JpaRepository<AbsenceAttendance, Long> {
     Page<AbsenceAttendance> findByCourseId(Long courseId, Pageable pageable);
 
-    @Query("SELECT new org.example.educheck.domain.absenceattendance.dto.response.MyAbsenceAttendanceResponseDto( " +
+    @Query(value = "SELECT new org.example.educheck.domain.absenceattendance.dto.response.MyAbsenceAttendanceResponseDto( " +
             "a.id, a.startTime, a.endTime, a.isApprove, a.category) " +
             "FROM AbsenceAttendance a " +
             "WHERE a.course.id = :courseId AND a.student.id = :studentId " +
-            "ORDER BY a.id DESC")
-    List<MyAbsenceAttendanceResponseDto> findByStudentIdAndCourseId(@Param("studentId") Long studentId, @Param("courseId") Long courseId);
+            "ORDER BY a.createdAt DESC",
+            countQuery = "SELECT COUNT(a) FROM AbsenceAttendance a " +
+                    "WHERE a.course.id = :courseId AND a.student.id = :studentId")
+    Page<MyAbsenceAttendanceResponseDto> findByStudentIdAndCourseId(@Param("studentId") Long studentId, @Param("courseId") Long courseId, Pageable pageable);
 
 }

--- a/api/src/main/java/org/example/educheck/domain/absenceattendance/repository/AbsenceAttendanceRepository.java
+++ b/api/src/main/java/org/example/educheck/domain/absenceattendance/repository/AbsenceAttendanceRepository.java
@@ -1,14 +1,22 @@
 package org.example.educheck.domain.absenceattendance.repository;
 
-import org.example.educheck.domain.absenceattendance.dto.response.AbsenceAttendanceResponseDto;
+import org.example.educheck.domain.absenceattendance.dto.response.MyAbsenceAttendanceResponseDto;
 import org.example.educheck.domain.absenceattendance.entity.AbsenceAttendance;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface AbsenceAttendanceRepository extends JpaRepository<AbsenceAttendance, Long> {
     Page<AbsenceAttendance> findByCourseId(Long courseId, Pageable pageable);
 
+    @Query("SELECT new org.example.educheck.domain.absenceattendance.dto.response.MyAbsenceAttendanceResponseDto( " +
+            "a.id, a.startTime, a.endTime, a.isApprove, a.category) " +
+            "FROM AbsenceAttendance a " +
+            "WHERE a.course.id = :courseId AND a.student.id = :studentId")
+    List<MyAbsenceAttendanceResponseDto> findByStudentIdAndCourseId(@Param("studentId") Long studentId, @Param("courseId") Long courseId);
 
-    AbsenceAttendanceResponseDto findDtoById(Long absenceAttendancesId);
 }

--- a/api/src/main/java/org/example/educheck/domain/absenceattendance/service/AbsenceAttendanceService.java
+++ b/api/src/main/java/org/example/educheck/domain/absenceattendance/service/AbsenceAttendanceService.java
@@ -5,10 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.example.educheck.domain.absenceattendance.dto.request.CreateAbsenceAttendacneRequestDto;
 import org.example.educheck.domain.absenceattendance.dto.request.ProcessAbsenceAttendanceRequestDto;
 import org.example.educheck.domain.absenceattendance.dto.request.UpdateAbsenceAttendacneRequestDto;
-import org.example.educheck.domain.absenceattendance.dto.response.AbsenceAttendanceResponseDto;
-import org.example.educheck.domain.absenceattendance.dto.response.CreateAbsenceAttendacneReponseDto;
-import org.example.educheck.domain.absenceattendance.dto.response.GetAbsenceAttendancesResponseDto;
-import org.example.educheck.domain.absenceattendance.dto.response.UpdateAbsenceAttendacneReponseDto;
+import org.example.educheck.domain.absenceattendance.dto.response.*;
 import org.example.educheck.domain.absenceattendance.entity.AbsenceAttendance;
 import org.example.educheck.domain.absenceattendance.repository.AbsenceAttendanceRepository;
 import org.example.educheck.domain.absenceattendanceattachmentfile.dto.response.AttachmentFileReposeDto;
@@ -251,5 +248,13 @@ public class AbsenceAttendanceService {
         if (!isCorrect) {
             throw new ForbiddenException("관리자가 관리하는 교육 과정에 대해서만 조회 가능합니다.");
         }
+    }
+
+    public List<MyAbsenceAttendanceResponseDto> getMyAbsenceAttendances(Member member, Long courseId) {
+
+        validateRegistrationCourse(member, courseId);
+
+        return absenceAttendanceRepository.findByStudentIdAndCourseId(member.getStudentId(), courseId);
+
     }
 }

--- a/api/src/main/java/org/example/educheck/domain/absenceattendance/service/AbsenceAttendanceService.java
+++ b/api/src/main/java/org/example/educheck/domain/absenceattendance/service/AbsenceAttendanceService.java
@@ -250,11 +250,11 @@ public class AbsenceAttendanceService {
         }
     }
 
-    public List<MyAbsenceAttendanceResponseDto> getMyAbsenceAttendances(Member member, Long courseId) {
+    public Page<MyAbsenceAttendanceResponseDto> getMyAbsenceAttendances(Member member, Long courseId, Pageable pageable) {
 
         validateRegistrationCourse(member, courseId);
 
-        return absenceAttendanceRepository.findByStudentIdAndCourseId(member.getStudentId(), courseId);
+        return absenceAttendanceRepository.findByStudentIdAndCourseId(member.getStudentId(), courseId, pageable);
 
     }
 }

--- a/api/src/main/java/org/example/educheck/global/common/exception/handler/GlobalExceptionHandler.java
+++ b/api/src/main/java/org/example/educheck/global/common/exception/handler/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.example.educheck.global.common.exception.ErrorCode;
 import org.example.educheck.global.common.exception.custom.LoginValidationException;
 import org.example.educheck.global.common.exception.custom.common.GlobalException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageConversionException;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -80,5 +81,13 @@ public class GlobalExceptionHandler {
                 .status(ErrorCode.MAX_UPLOAD_SIZE_EXCEEDED.getStatus())
                 .body(ApiResponse.error(ErrorCode.MAX_UPLOAD_SIZE_EXCEEDED.getMessage(),
                         ErrorCode.MAX_UPLOAD_SIZE_EXCEEDED.getCode()));
+    }
+
+    @ExceptionHandler(HttpMessageConversionException.class)
+    public ResponseEntity<ApiResponse<Object>> handleHttpMessageConversionException(HttpMessageConversionException ex) {
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT.getStatus())
+                .body(ApiResponse.error(ErrorCode.INVALID_INPUT.getMessage(),
+                        ErrorCode.INVALID_INPUT.getCode()));
     }
 }


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- EC-127

## 📝 변경 사항

- 페이지당 조회 SIZE 4개로 했습니다 (피그마 참고)
- 신청 날짜가 최근인 순으로 정렬 
- API 엔드포인트
```
/my/course/{courseId}/absence-attendances?page=1
```

## ✅ PR 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [ ] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트

## 📌 참고 사항
