### PR TITLE
[EC-31] BE/feat: 수강생 수강 상태 수정 api

### DIFF
--- a/api/src/main/java/org/example/educheck/domain/member/staff/controller/StaffController.java
+++ b/api/src/main/java/org/example/educheck/domain/member/staff/controller/StaffController.java
@@ -1,0 +1,37 @@
+package org.example.educheck.domain.member.staff.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.educheck.domain.member.entity.Member;
+import org.example.educheck.domain.member.staff.dto.request.UpdateStudentRegistrationStatusRequestDto;
+import org.example.educheck.domain.member.staff.dto.response.UpdateStudentRegistrationStatusResponseDto;
+import org.example.educheck.domain.member.staff.service.StaffService;
+import org.example.educheck.global.common.dto.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class StaffController {
+    private final StaffService staffService;
+
+    @PreAuthorize("hasAuthority('MIDDLE_ADMIN')")
+    @PutMapping("/course/{courseId}/student/{studentId}")
+    public ResponseEntity<ApiResponse<UpdateStudentRegistrationStatusResponseDto>> updateStudentRegistrationStatus(
+            @AuthenticationPrincipal Member member,
+            @PathVariable Long courseId,
+            @PathVariable Long studentId,
+            @RequestBody UpdateStudentRegistrationStatusRequestDto requestDto) {
+
+        return ResponseEntity.ok(
+                ApiResponse.ok("수강생 등록 상태 변경 성공",
+                        "OK",
+                        staffService.updateStudentRegistrationStatus(member, courseId, studentId, requestDto)));
+    }
+
+
+}

--- a/api/src/main/java/org/example/educheck/domain/member/staff/dto/request/UpdateStudentRegistrationStatusRequestDto.java
+++ b/api/src/main/java/org/example/educheck/domain/member/staff/dto/request/UpdateStudentRegistrationStatusRequestDto.java
@@ -1,0 +1,15 @@
+package org.example.educheck.domain.member.staff.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.example.educheck.domain.registration.entity.Status;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UpdateStudentRegistrationStatusRequestDto {
+
+    private Status status;
+
+}

--- a/api/src/main/java/org/example/educheck/domain/member/staff/dto/response/UpdateStudentRegistrationStatusResponseDto.java
+++ b/api/src/main/java/org/example/educheck/domain/member/staff/dto/response/UpdateStudentRegistrationStatusResponseDto.java
@@ -1,0 +1,31 @@
+package org.example.educheck.domain.member.staff.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.educheck.domain.registration.entity.Status;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+public class UpdateStudentRegistrationStatusResponseDto {
+
+    private Long studentId;
+    private Long courseId;
+    private String studentName;
+    private String courseName;
+    private Status status;
+
+    public static UpdateStudentRegistrationStatusResponseDto from(Long studentId, Long courseId, String studentName, String courseName, Status status) {
+        return UpdateStudentRegistrationStatusResponseDto.builder()
+                .studentId(studentId)
+                .courseId(courseId)
+                .studentName(studentName)
+                .courseName(courseName)
+                .status(status)
+                .build();
+    }
+
+}

--- a/api/src/main/java/org/example/educheck/domain/member/staff/service/StaffService.java
+++ b/api/src/main/java/org/example/educheck/domain/member/staff/service/StaffService.java
@@ -1,0 +1,77 @@
+package org.example.educheck.domain.member.staff.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.educheck.domain.course.entity.Course;
+import org.example.educheck.domain.course.repository.CourseRepository;
+import org.example.educheck.domain.member.entity.Member;
+import org.example.educheck.domain.member.repository.MemberRepository;
+import org.example.educheck.domain.member.staff.dto.request.UpdateStudentRegistrationStatusRequestDto;
+import org.example.educheck.domain.member.staff.dto.response.UpdateStudentRegistrationStatusResponseDto;
+import org.example.educheck.domain.member.staff.entity.Staff;
+import org.example.educheck.domain.member.repository.StaffRepository;
+import org.example.educheck.domain.member.student.entity.Student;
+import org.example.educheck.domain.registration.entity.Registration;
+import org.example.educheck.domain.registration.repository.RegistrationRepository;
+import org.example.educheck.domain.staffcourse.repository.StaffCourseRepository;
+import org.example.educheck.global.common.exception.custom.common.ForbiddenException;
+import org.example.educheck.global.common.exception.custom.common.InvalidRequestException;
+import org.example.educheck.global.common.exception.custom.common.ResourceNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StaffService {
+
+    private final RegistrationRepository registrationRepository;
+    private final CourseRepository courseRepository;
+    private final MemberRepository memberRepository;
+    private final StaffRepository staffRepository;
+    private final StaffCourseRepository staffCourseRepository;
+
+    @Transactional
+    public UpdateStudentRegistrationStatusResponseDto updateStudentRegistrationStatus(Member member, Long courseId, Long studentId, UpdateStudentRegistrationStatusRequestDto requestDto) {
+
+        // 1. 관리자 권한 검증
+        Staff staff = staffRepository.findByMember(member)
+                .orElseThrow(() -> new ResourceNotFoundException("관리자 정보를 찾을 수 없습니다."));
+
+        // 2. 관리자가 해당 코스를 관리하는지 확인
+        validateStaffManageCourse(staff.getId(), courseId);
+
+        // 3. 코스 정보 조회
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new ResourceNotFoundException("해당 교육 과정을 찾을 수 없습니다."));
+
+        // 4. 학생 정보 조회
+        Member studentMember = memberRepository.findByStudent_Id(studentId)
+                .orElseThrow(() -> new ResourceNotFoundException("해당 학생을 찾을 수 없습니다."));
+        Student student = studentMember.getStudent();
+
+        // 5. 수강 정보 조회
+        Registration registration = registrationRepository.findByStudentIdAndCourseId(studentId, courseId)
+                .orElseThrow(() -> new ResourceNotFoundException("해당 학생의 수강 정보를 찾을 수 없습니다."));
+
+        // 6. 수강 상태 업데이트
+        registration.setStatus(requestDto.getStatus());
+
+        // 7. 응답 DTO 생성 및 반환
+        return UpdateStudentRegistrationStatusResponseDto.from(
+                studentId,
+                courseId,
+                studentMember.getName(),
+                course.getName(),
+                requestDto.getStatus()
+        );
+    }
+
+    private void validateStaffManageCourse(Long staffId, Long courseId) {
+        boolean isCorrect = staffCourseRepository.existsByStaffIdAndCourseId(staffId, courseId);
+        if (!isCorrect) {
+            throw new ForbiddenException("관리자가 관리하는 교육 과정에 대해서만 수정 가능합니다.");
+        }
+    }
+}

--- a/api/src/main/java/org/example/educheck/domain/registration/entity/Registration.java
+++ b/api/src/main/java/org/example/educheck/domain/registration/entity/Registration.java
@@ -1,15 +1,13 @@
 package org.example.educheck.domain.registration.entity;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.example.educheck.domain.course.entity.Course;
 import org.example.educheck.domain.member.student.entity.Student;
 
 @Getter
 @Entity
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Registration {
 


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- EC-31

## 📝 변경 사항

- 수강생 수강 상태 수정 api 구현
- registration Setter 어노테이션 추가



## ✅ PR 체크리스트

- [ ] 커밋 메시지에 Jira 이슈 번호 포함
- [ ] 관련 문서 업데이트 (필요한 경우)
- [ ] Jira 이슈 상태 업데이트

## 📌 참고 사항

